### PR TITLE
chore/fix: Add editorconfig, fix typo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,7 +24,7 @@ const translation = useTranslations(lang);
 				<li><a href="https://aux.computer/contribute">Contribute</a></li>
 			-->
 				<li><a href="https://forum.aux.computer">{translation("header.community")}</a></li>
-				<li><a href="https://github.com/auxolotl">Github</a></li>
+				<li><a href="https://github.com/auxolotl">GitHub</a></li>
 			</ul>
 		</nav>
 	</div>


### PR DESCRIPTION
Hi,

quick PR, adds a `.editorconfig` file (which is always nice) and fixes a typo in the casing of `GitHub` in the header bar. Although we do not plan on staying here, correctly spelling things is still good :^)

As for the `.editorconfig`, I've choosen `4` as tab width, although wasn't sure if we prefer `8` here?