### PR TITLE
refactor: Avoid duplicating pages for each language

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,11 +1,11 @@
 ---
 interface Props {}
 
-import { getLangFromUrl, useTranslations } from '../i18n/utils';
+import { useTranslations } from '../i18n/utils';
 import { Image } from 'astro:assets';
 import aux from '../../public/aux.svg';
 
-const lang = getLangFromUrl(Astro.url);
+const { lang } = Astro.params;
 const translation = useTranslations(lang);
 ---
 

--- a/src/components/home/Goals.astro
+++ b/src/components/home/Goals.astro
@@ -1,7 +1,7 @@
 ---
-import { getLangFromUrl, useTranslations } from '../../i18n/utils';
+import { useTranslations } from '../../i18n/utils';
 
-const lang = getLangFromUrl(Astro.url);
+const { lang } = Astro.params;
 const translation = useTranslations(lang);
 ---
 

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -1,9 +1,9 @@
 ---
-import { getLangFromUrl, useTranslations } from '../../i18n/utils';
+import { useTranslations } from '../../i18n/utils';
 import { Image } from 'astro:assets';
 import aux from '../../../public/aux.svg';
 
-const lang = getLangFromUrl(Astro.url);
+const { lang } = Astro.params;
 const translation = useTranslations(lang);
 ---
 

--- a/src/components/home/Roadmap.astro
+++ b/src/components/home/Roadmap.astro
@@ -1,7 +1,7 @@
 ---
-import { getLangFromUrl, useTranslations } from '../../i18n/utils';
+import { useTranslations } from '../../i18n/utils';
 
-const lang = getLangFromUrl(Astro.url);
+const { lang } = Astro.params;
 const translation = useTranslations(lang);
 ---
 

--- a/src/components/home/Values.astro
+++ b/src/components/home/Values.astro
@@ -1,7 +1,7 @@
 ---
-import { getLangFromUrl, useTranslations } from '../../i18n/utils';
+import { useTranslations } from '../../i18n/utils';
 
-const lang = getLangFromUrl(Astro.url);
+const { lang } = Astro.params;
 const translation = useTranslations(lang);
 ---
 

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,11 +1,5 @@
 import { ui, defaultLang } from './ui';
 
-export function getLangFromUrl(url: URL) {
-	const [, lang] = url.pathname.split('/');
-	if (lang in ui) return lang as keyof typeof ui;
-	return defaultLang;
-}
-
 export function useTranslations(lang: keyof typeof ui) {
 	return function t(key: keyof typeof ui[typeof defaultLang]) {
 		return ui[lang][key] || ui[defaultLang][key];

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,4 @@
 ---
-import { getLangFromUrl } from '../i18n/utils';
 import Header from "../components/Header.astro";
 
 interface Props {
@@ -7,8 +6,7 @@ interface Props {
 }
 
 const { title } = Astro.props;
-
-const lang = getLangFromUrl(Astro.url);
+const { lang } = Astro.params;
 ---
 
 <!doctype html>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,0 +1,15 @@
+---
+import { languages } from "../../i18n/ui";
+import Layout from "../../layouts/Layout.astro";
+import Home from "../../components/home/Home.astro";
+
+export async function getStaticPaths() {
+	return Object.keys(languages).map((name) => (
+		{ params: { lang: name } }
+	))
+}
+---
+
+<Layout title="auxolotl.org">
+	<Home />
+</Layout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,8 +1,0 @@
----
-import Layout from "../../layouts/Layout.astro";
-import Home from "../../components/home/Home.astro";
----
-
-<Layout title="auxolotl.org">
-	<Home />
-</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0;url=/en/" />
+---
+import { defaultLang } from '../i18n/ui';
+---
+
+<meta http-equiv="refresh" content=`0;url=/${defaultLang}/` />


### PR DESCRIPTION
#10 added support for per-lang pages. This PR makes them dynamic.

It makes use of Astro dynamic routing to avoid having to redefine all pages for each language.

Note that they still have to be defined in `i18n/ui.ts` which is not refactored in this PR.

The Index will also now use the `defaultLang` from `i18n/ui.ts` rather than hardcoding `/en/`.

Let me know if I did something wrong since I'm not very familiar with Astro 😄

**NOTE**: Unfortunately, this refactor causes merge conflicts in the translation PRs. If you're working on a translation draft and this PR is merged, please update your PRs! There's no need for a `pages/<your_language>/index.astro` anymore. 