### PR TITLE
chore: format robots.txt.yml with prettier (fix CI)

### DIFF
--- a/.github/workflows/robots.txt.yml
+++ b/.github/workflows/robots.txt.yml
@@ -1,34 +1,33 @@
 name: "Update robots.txt"
 on:
-  schedule:
-  - cron: "0 0 * * 6" # At 00:00 on Saturday
-  workflow_dispatch:
+    schedule:
+        - cron: "0 0 * * 6" # At 00:00 on Saturday
+    workflow_dispatch:
 
 jobs:
-  update:
-    name: "Update robots.txt"
+    update:
+        name: "Update robots.txt"
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
+        permissions:
+            contents: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Pull latest robots
-        run: |
-          curl -X POST https://api.darkvisitors.com/robots-txts \
-              -H "Authorization: Bearer ${{ secrets.DarkVisitorsBearer }}" \
-              -H "Content-Type: application/json" \
-              --data-raw '{"agent_types": ["AI Assistant", "AI Data Scraper", "AI Search Crawler", "Undocumented AI Agent"]}' \
-              --output ./public/robots.txt
+            - name: Pull latest robots
+              run: |
+                  curl -X POST https://api.darkvisitors.com/robots-txts \
+                      -H "Authorization: Bearer ${{ secrets.DarkVisitorsBearer }}" \
+                      -H "Content-Type: application/json" \
+                      --data-raw '{"agent_types": ["AI Assistant", "AI Data Scraper", "AI Search Crawler", "Undocumented AI Agent"]}' \
+                      --output ./public/robots.txt
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-           message: "chore: generate robots.txt"
-           default_author: github_actions
-           push: true
-
+            - name: Commit changes
+              uses: EndBug/add-and-commit@v9
+              with:
+                  message: "chore: generate robots.txt"
+                  default_author: github_actions
+                  push: true


### PR DESCRIPTION
#8 which added the file being WIP seems to have prevented these checks from running. this file is making CI fail on other PRs that have synced to main. unfortunately, this loses the git blame information on the file, but force-pushing to fix formatting would be nightmarish for our current open PRs...