### PR TITLE
feat(i18n): display banner for outdated translations

### DIFF
--- a/public/locales/dk/translations.json
+++ b/public/locales/dk/translations.json
@@ -1,4 +1,5 @@
 {
+	"version": 0,
 	"root.description": "Et alternativ til Nix økosystemet",
 
 	"header.community": "Community",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1,4 +1,8 @@
 {
+	"version": 0,
+	"i18n-outdated.title": "Outdated Translation",
+	"i18n-outdated.description": "This translation has not been updated to the latest version yet.",
+
 	"root.description": "An alternative to the Nix ecosystem",
 
 	"header.community": "Community",

--- a/src/components/home/Home.astro
+++ b/src/components/home/Home.astro
@@ -12,15 +12,9 @@ import { isOutdated as i18nIsOutdated } from "../../i18n/utils";
 ---
 
 <main class="grid place-items-center">
-	<Hero />
+	{i18nIsOutdated(lang) && <I18nOutdated />}
 
-	{
-		i18nIsOutdated(lang) && (
-			<div class="prose prose-invert py-16 px-4 max-w-4xl">
-				<I18nOutdated />
-			</div>
-		)
-	}
+	<Hero />
 
 	<div class="prose prose-invert py-16 px-4 max-w-4xl">
 		<Values />

--- a/src/components/home/Home.astro
+++ b/src/components/home/Home.astro
@@ -3,10 +3,24 @@ import Hero from "./Hero.astro";
 import Values from "./Values.astro";
 import Goals from "./Goals.astro";
 import Roadmap from "./Roadmap.astro";
+import I18nOutdated from "../i18n/Outdated.astro";
+
+import type { Params } from "../../i18n/utils";
+
+const { lang } = Astro.params as Params;
+import { isOutdated as i18nIsOutdated } from "../../i18n/utils";
 ---
 
 <main class="grid place-items-center">
 	<Hero />
+
+	{
+		i18nIsOutdated(lang) && (
+			<div class="prose prose-invert py-16 px-4 max-w-4xl">
+				<I18nOutdated />
+			</div>
+		)
+	}
 
 	<div class="prose prose-invert py-16 px-4 max-w-4xl">
 		<Values />

--- a/src/components/i18n/Outdated.astro
+++ b/src/components/i18n/Outdated.astro
@@ -1,0 +1,14 @@
+---
+import { useTranslations } from "../../i18n/utils";
+import type { Params } from "../../i18n/utils";
+
+const { lang } = Astro.params as Params;
+const translation = useTranslations(lang);
+---
+
+<section id="i18n-outdated">
+	<h2>{translation("i18n-outdated.title")}</h2>
+	<p class="description">
+		{translation("i18n-outdated.description")}
+	</p>
+</section>

--- a/src/components/i18n/Outdated.astro
+++ b/src/components/i18n/Outdated.astro
@@ -6,7 +6,11 @@ const { lang } = Astro.params as Params;
 const translation = useTranslations(lang);
 ---
 
-<section id="i18n-outdated">
+<section
+	id="i18n-outdated"
+	class="prose prose-invert w-full max-w-4xl bg-yellow-800 bg-opacity-50 border-l-4 border-orange-500 text-orange-100 p-4"
+	role="alert"
+>
 	<h2>{translation("i18n-outdated.title")}</h2>
 	<p class="description">
 		{translation("i18n-outdated.description")}

--- a/src/components/i18n/Outdated.astro
+++ b/src/components/i18n/Outdated.astro
@@ -8,11 +8,9 @@ const translation = useTranslations(lang);
 
 <section
 	id="i18n-outdated"
-	class="prose prose-invert w-full max-w-4xl bg-yellow-800 bg-opacity-50 border-l-4 border-orange-500 text-orange-100 p-4"
+	class="w-full max-w-4xl bg-yellow-800 bg-opacity-50 border-l-4 border-orange-500 text-orange-100 p-4"
 	role="alert"
 >
-	<h2>{translation("i18n-outdated.title")}</h2>
-	<p class="description">
-		{translation("i18n-outdated.description")}
-	</p>
+	<p class="font-bold">{translation("i18n-outdated.title")}</p>
+	<p>{translation("i18n-outdated.description")}</p>
 </section>

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -11,6 +11,14 @@ export function useTranslations(lang: keyof typeof ui) {
 	};
 }
 
+export function isOutdated(lang: keyof typeof ui) {
+	if ("version" in ui[lang]) {
+		return ui[lang]["version"] < ui[defaultLang]["version"];
+	} else {
+		return true;
+	}
+}
+
 export const getStaticPaths = (async () => {
 	return Object.keys(languages).map((name) => ({
 		params: { lang: name as keyof typeof languages },

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -13,7 +13,10 @@ export function useTranslations(lang: keyof typeof ui) {
 
 export function isOutdated(lang: keyof typeof ui) {
 	if ("version" in ui[lang]) {
-		return ui[lang]["version"] < ui[defaultLang]["version"];
+		return (
+			(ui[lang] as (typeof ui)[typeof lang])["version"] <
+			ui[defaultLang]["version"]
+		);
 	} else {
 		return true;
 	}


### PR DESCRIPTION
Displays a "banner" for outdated translations.

'Outdated' is recognized by having an explicit `version` field in each translation file.

---

For testing purposes, only the danish translation has a `version` field, so that the german translation shows as outdated.

I've not worked with tailwind before, so I'm really lost at getting this appropriately styled though.