### PR TITLE
fix: update sigs-and-committees link

### DIFF
--- a/src/components/home/Goals.astro
+++ b/src/components/home/Goals.astro
@@ -23,7 +23,7 @@ const translation = useTranslations(lang);
 				</p>
 				<p>
 					<a
-						href="https://wiki.auxolotl.org/en/contributing/sigs-and-committees"
+						href="https://wiki.auxolotl.org/community"
 						target="_blank"
 						rel="noopener noreferrer"
 					>


### PR DESCRIPTION
In wiki commit 4fa47a6c192535c8412a068394cdc1ac4a0d5a81, we moved the committees page to /community. This commit makes the same change to the link on the roadmap